### PR TITLE
Fix the symlink argument order

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To load the extension from a git checkout instead of a package:
     git clone https://github.com/yob/emoji-selector-for-gnome.git
     cd emoji-selector-for-gnome
     git checkout single-emoji-data-file
-    ln -s ~/.local/share/gnome-shell/extensions/emoji-selector@maestroschan.fr <path to git clone>
+    ln -s <path to git clone> ~/.local/share/gnome-shell/extensions/emoji-selector@maestroschan.fr
 
 .. and then restart your gnome-shell session, or to test without restarting you can use
 the dbus-run-session trick above.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To load the extension from a git checkout instead of a package:
     git clone https://github.com/yob/emoji-selector-for-gnome.git
     cd emoji-selector-for-gnome
     git checkout single-emoji-data-file
-    ln -s <path to git clone> ~/.local/share/gnome-shell/extensions/emoji-selector@maestroschan.fr
+    ln -s <path to git clone>/emoji-selector@maestroschan.fr ~/.local/share/gnome-shell/extensions/emoji-selector@maestroschan.fr
 
 .. and then restart your gnome-shell session, or to test without restarting you can use
 the dbus-run-session trick above.


### PR DESCRIPTION
I'm not sure if I'm missing something, but I think the symlink arguments are around the wrong way.